### PR TITLE
change url for js2wasm from fermyon to spinframework

### DIFF
--- a/manifests/js2wasm/js2wasm.json
+++ b/manifests/js2wasm/js2wasm.json
@@ -1,7 +1,7 @@
 {
   "name": "js2wasm",
   "description": "A plugin to convert js files to Spin compatible modules",
-  "homepage": "https://github.com/fermyon/spin-js-sdk",
+  "homepage": "https://github.com/spinframework/spin-js-sdk",
   "version": "0.6.1",
   "spinCompatibility": ">=1.5",
   "license": "Apache-2.0",
@@ -9,31 +9,31 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-linux-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-linux-amd64.tar.gz",
       "sha256": "2349ebb6ac8ea6e1ced026b98fb5eb6146740d736558c7e032aef10ef545e135"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-linux-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-linux-aarch64.tar.gz",
       "sha256": "6419f5282024773f4be37fc8c232cc56113a485bc375606ca4f4c148444587f6"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-macos-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-macos-aarch64.tar.gz",
       "sha256": "5c8cff7e71ddc0865d9c13471b3ffbc87753a67ea275fece60d33c4062a4fa36"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-macos-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-macos-amd64.tar.gz",
       "sha256": "3ac376e3ad900980e45c504815cdc901122405ef6244a36684ac843968f488bd"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-windows-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.1/js2wasm-v0.6.1-windows-amd64.tar.gz",
       "sha256": "98d3c0d8aeabd9a632dd4dd3a7a405dab27a1b7cd6b45edeec978f013e3aea12"
     }
   ]

--- a/manifests/js2wasm/js2wasm@0.1.0.json
+++ b/manifests/js2wasm/js2wasm@0.1.0.json
@@ -1,7 +1,7 @@
 {
   "name": "js2wasm",
   "description": "A plugin to convert js files to Spin compatible modules",
-  "homepage": "https://github.com/fermyon/spin-js-sdk",
+  "homepage": "https://github.com/spinframework/spin-js-sdk",
   "version": "0.1.0",
   "spinCompatibility": ">=0.6",
   "license": "Apache-2.0",
@@ -9,25 +9,25 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.1.0/js2wasm-v0.1.0-linux-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.1.0/js2wasm-v0.1.0-linux-amd64.tar.gz",
       "sha256": "e00e41dc3eb5d5eda996209e4aa22dbee55f62ea58f7cc854524a74274af529e"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.1.0/js2wasm-v0.1.0-macos-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.1.0/js2wasm-v0.1.0-macos-aarch64.tar.gz",
       "sha256": "2946c6a8cb90ecff48982ce339e83a6fb9a20af749cd0664edddc8566fc749aa"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.1.0/js2wasm-v0.1.0-macos-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.1.0/js2wasm-v0.1.0-macos-amd64.tar.gz",
       "sha256": "4ece97879fb6a940f44dd3ef43c48b3af75825f8a1b307e76246ced73ce661b9"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.1.0/js2wasm-v0.1.0-windows-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.1.0/js2wasm-v0.1.0-windows-amd64.tar.gz",
       "sha256": "d6c0cd92a57ad4ae1f4dc343d106b8bb69ac4cab9cc7cca2ef05318f9d03134b"
     }
   ]

--- a/manifests/js2wasm/js2wasm@0.2.0.json
+++ b/manifests/js2wasm/js2wasm@0.2.0.json
@@ -1,7 +1,7 @@
 {
   "name": "js2wasm",
   "description": "A plugin to convert js files to Spin compatible modules",
-  "homepage": "https://github.com/fermyon/spin-js-sdk",
+  "homepage": "https://github.com/spinframework/spin-js-sdk",
   "version": "0.2.0",
   "spinCompatibility": ">=0.7",
   "license": "Apache-2.0",
@@ -9,31 +9,31 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-linux-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-linux-amd64.tar.gz",
       "sha256": "26ac42b69bea41c954e0e176d1f573396825247bf2ba22dd834974a35b042b9b"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-linux-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-linux-aarch64.tar.gz",
       "sha256": "37a3411c4c2d589bacfbfdd621529ccd435618ca9808c7e855f6ffad0460c55e"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-macos-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-macos-aarch64.tar.gz",
       "sha256": "3813c29f886993a81ecdc493632515178a457e803a4f2abb86bf17782c234c9d"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-macos-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-macos-amd64.tar.gz",
       "sha256": "d47548a2142b9e71bbf2d8247464c128e6b60f907dde42aa364638e8708f3582"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-windows-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.2.0/js2wasm-v0.2.0-windows-amd64.tar.gz",
       "sha256": "a792f363c33472ab1936b0adf2d3f3411c69001c1c6a6d70a37114c0e36cf58b"
     }
   ]

--- a/manifests/js2wasm/js2wasm@0.3.0.json
+++ b/manifests/js2wasm/js2wasm@0.3.0.json
@@ -1,7 +1,7 @@
 {
   "name": "js2wasm",
   "description": "A plugin to convert js files to Spin compatible modules",
-  "homepage": "https://github.com/fermyon/spin-js-sdk",
+  "homepage": "https://github.com/spinframework/spin-js-sdk",
   "version": "0.3.0",
   "spinCompatibility": ">=0.7",
   "license": "Apache-2.0",
@@ -9,31 +9,31 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-linux-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-linux-amd64.tar.gz",
       "sha256": "1ea5d61ca2a9c8396adb4e7059e24353e4d3db294f2636642fcacb86154dfedc"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-linux-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-linux-aarch64.tar.gz",
       "sha256": "53b6f8dbd5871cd017c41520b0421df4081e5a6de872b77fce56319a8eb150bf"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-macos-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-macos-aarch64.tar.gz",
       "sha256": "029f56f07f43d503f17f00507e97aa70be0ea17467951d3a6e2af922cedf7c7d"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-macos-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-macos-amd64.tar.gz",
       "sha256": "f8f8d00b9cd884169e2b38c01283c06a87ccd859a16cfe12a3120a880c067181"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-windows-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.3.0/js2wasm-v0.3.0-windows-amd64.tar.gz",
       "sha256": "f70ea07c9639d991ba5209b5e782b8bfb8d0c01bc0c511ace5f579889624e3a5"
     }
   ]

--- a/manifests/js2wasm/js2wasm@0.4.0.json
+++ b/manifests/js2wasm/js2wasm@0.4.0.json
@@ -1,7 +1,7 @@
 {
   "name": "js2wasm",
   "description": "A plugin to convert js files to Spin compatible modules",
-  "homepage": "https://github.com/fermyon/spin-js-sdk",
+  "homepage": "https://github.com/spinframework/spin-js-sdk",
   "version": "0.4.0",
   "spinCompatibility": ">=0.9",
   "license": "Apache-2.0",
@@ -9,31 +9,31 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-linux-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-linux-amd64.tar.gz",
       "sha256": "7b021bcf9398863305fec7d921625d9efa37eaef21a8282271b780a9042e6a80"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-linux-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-linux-aarch64.tar.gz",
       "sha256": "5ee58b850b04b0ef45f928c6dbe3a66e8956e72c1632a57f5f355b24ba8c3d07"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-macos-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-macos-aarch64.tar.gz",
       "sha256": "ea7ad9c8c48f407309b09a4f29f25095af952d1cb7875972e813155c8922054d"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-macos-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-macos-amd64.tar.gz",
       "sha256": "63a29d9828c6484988f74ffc3393fd3a9b821c050be951dd9703522131e4418c"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-windows-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.4.0/js2wasm-v0.4.0-windows-amd64.tar.gz",
       "sha256": "a286b1dd67498016bf540e9dbb34ad8877e3dee141bd8a3f53c10c97a38dc2b1"
     }
   ]

--- a/manifests/js2wasm/js2wasm@0.5.0.json
+++ b/manifests/js2wasm/js2wasm@0.5.0.json
@@ -1,7 +1,7 @@
 {
   "name": "js2wasm",
   "description": "A plugin to convert js files to Spin compatible modules",
-  "homepage": "https://github.com/fermyon/spin-js-sdk",
+  "homepage": "https://github.com/spinframework/spin-js-sdk",
   "version": "0.5.0",
   "spinCompatibility": ">=1.4",
   "license": "Apache-2.0",
@@ -9,31 +9,31 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-linux-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-linux-amd64.tar.gz",
       "sha256": "875c141e909d12eed7e27c39f5ed7700e78f9f10733318e4dbd517e245ebb380"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-linux-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-linux-aarch64.tar.gz",
       "sha256": "096c0f2e1bcdd3965a80841dd3dbcf41cf6f3cb54c1e7f5e69a6fe52360429c4"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-macos-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-macos-aarch64.tar.gz",
       "sha256": "bcb8bcec417d466e5cfe2231aea7b28b515a862babef0efd94f0a3b05b31b833"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-macos-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-macos-amd64.tar.gz",
       "sha256": "2d3475dba5a66b3ffa2465c8195bfa4697f3704de3de6c470ca10a9c1da6e414"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-windows-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.0/js2wasm-v0.5.0-windows-amd64.tar.gz",
       "sha256": "2e27a39e698d40927aca0cdbf5144d34af30e15f2497f1337aa391d755fc70f9"
     }
   ]

--- a/manifests/js2wasm/js2wasm@0.5.1.json
+++ b/manifests/js2wasm/js2wasm@0.5.1.json
@@ -1,7 +1,7 @@
 {
   "name": "js2wasm",
   "description": "A plugin to convert js files to Spin compatible modules",
-  "homepage": "https://github.com/fermyon/spin-js-sdk",
+  "homepage": "https://github.com/spinframework/spin-js-sdk",
   "version": "0.5.1",
   "spinCompatibility": ">=1.4",
   "license": "Apache-2.0",
@@ -9,31 +9,31 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-linux-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-linux-amd64.tar.gz",
       "sha256": "5c9afda199f870cd2da62451ebbe101746b2b63cca2ed0dd1940c1495ba28871"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-linux-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-linux-aarch64.tar.gz",
       "sha256": "44db108c856eac4832951c1f07170bb4d1cb6259dc08bfd41e92c88caa838137"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-macos-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-macos-aarch64.tar.gz",
       "sha256": "155c6ef2a33936c3c1bf37db38c3a2dfcd0b261511a31abda2fb4cbefb3f8d9d"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-macos-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-macos-amd64.tar.gz",
       "sha256": "01437f27d14336f3faf48f07857785587c2b45c22f5aafb8120525308d6630cb"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-windows-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.5.1/js2wasm-v0.5.1-windows-amd64.tar.gz",
       "sha256": "462279398446059d307b391b7e10f9b5f94574e0cc00817ac55da183577a6b0f"
     }
   ]

--- a/manifests/js2wasm/js2wasm@0.6.0.json
+++ b/manifests/js2wasm/js2wasm@0.6.0.json
@@ -1,7 +1,7 @@
 {
   "name": "js2wasm",
   "description": "A plugin to convert js files to Spin compatible modules",
-  "homepage": "https://github.com/fermyon/spin-js-sdk",
+  "homepage": "https://github.com/spinframework/spin-js-sdk",
   "version": "0.6.0",
   "spinCompatibility": ">=1.5",
   "license": "Apache-2.0",
@@ -9,31 +9,31 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-linux-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-linux-amd64.tar.gz",
       "sha256": "b6420ce8a8aba84fc343442591dcdab99781efb78b16e6372f445dcae3440eb9"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-linux-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-linux-aarch64.tar.gz",
       "sha256": "763cf44b1c7d83e5f37cd7b934711b6bf847bc986a082a68888069e5ca9489bc"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-macos-aarch64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-macos-aarch64.tar.gz",
       "sha256": "c6379d647d46cc188d7fc438304711b9cdfee26a9431e6c3c4d0278d828d97b4"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-macos-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-macos-amd64.tar.gz",
       "sha256": "77290c2d4899e4bd3965b3ee51f7b1f2f72c6d836906e5904ee69a84a0b7697c"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-windows-amd64.tar.gz",
+      "url": "https://github.com/spinframework/spin-js-sdk/releases/download/v0.6.0/js2wasm-v0.6.0-windows-amd64.tar.gz",
       "sha256": "fb4f731f0019aea75aaa613fe0270bb54eb29fd7db779ac34996e6084952e818"
     }
   ]


### PR DESCRIPTION
It seems we added a placeholder repo for github.com/fermyon/spin-js-sdk, which breaks existing plugin release urls.

I discovered this issue while testing move of `actions` repo rto `spinframework` org: https://github.com/rajatjindal/spinframework-actions/actions/runs/14810087267/job/41583714412?pr=11