### PR TITLE
Publish trigger plugin manifests

### DIFF
--- a/manifests/trigger-command/trigger-command.json
+++ b/manifests/trigger-command/trigger-command.json
@@ -1,39 +1,39 @@
 {
   "name": "trigger-command",
   "description": "A Spin trigger that executes the WASI main function of a component.",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "spinCompatibility": ">=2.0",
   "license": "Apache-2.0",
   "packages": [
     {
       "os": "macos",
-      "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-macos-aarch64.tar.gz",
-      "sha256": "638241e35b065e181cd87b7f2d7163ddb7c299e5992c4420f217972c51a46090"
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.4.0/trigger-command-0.4.0-macos-amd64.tar.gz",
+      "sha256": "323542b6e5ccb32ca1f48ec18b953c2006d72da629369f73a8d844241b6d5086"
     },
     {
       "os": "linux",
-      "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-linux-amd64.tar.gz",
-      "sha256": "ed5dc94f9b1b935684f1ef0bf7efec610cd877590e2a12433323469461c72290"
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.4.0/trigger-command-0.4.0-linux-aarch64.tar.gz",
+      "sha256": "47c53274826536d35f5cc1e831a503e19172b85711315557f97a659890032fbf"
     },
     {
       "os": "macos",
-      "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-macos-amd64.tar.gz",
-      "sha256": "e4b7c78247890c67718183e896d47d84fa5d5b52e53bfecbf33ab007ab3f6540"
-    },
-    {
-      "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-linux-aarch64.tar.gz",
-      "sha256": "87809aca568009fcd90bd50e0e189444915f3a2e33e459f6c9bc46fa466fe769"
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.4.0/trigger-command-0.4.0-macos-aarch64.tar.gz",
+      "sha256": "85510c9b395f0b5e4fc235cac94cca67231bf8fe26e973dc15bc9e9cf656f404"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-windows-amd64.tar.gz",
-      "sha256": "2d25b50d8cab4862810b4a82b1cf1a51090cc0a1c7aed48fe454a93670c5ad4a"
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.4.0/trigger-command-0.4.0-windows-amd64.tar.gz",
+      "sha256": "d3b0ca69f2a687174653c782586faf90a0d6cc1df26a34e7be16897a921c4a17"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.4.0/trigger-command-0.4.0-linux-amd64.tar.gz",
+      "sha256": "9fb23fad4f315b64d105950f12a4ad89d46ad4ab5df65c76df76c215a5fd2387"
     }
   ]
 }

--- a/manifests/trigger-command/trigger-command@0.3.2.json
+++ b/manifests/trigger-command/trigger-command@0.3.2.json
@@ -1,0 +1,39 @@
+{
+  "name": "trigger-command",
+  "description": "A Spin trigger that executes the WASI main function of a component.",
+  "version": "0.3.2",
+  "spinCompatibility": ">=2.0",
+  "license": "Apache-2.0",
+  "packages": [
+    {
+      "os": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-macos-aarch64.tar.gz",
+      "sha256": "638241e35b065e181cd87b7f2d7163ddb7c299e5992c4420f217972c51a46090"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-linux-amd64.tar.gz",
+      "sha256": "ed5dc94f9b1b935684f1ef0bf7efec610cd877590e2a12433323469461c72290"
+    },
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-macos-amd64.tar.gz",
+      "sha256": "e4b7c78247890c67718183e896d47d84fa5d5b52e53bfecbf33ab007ab3f6540"
+    },
+    {
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-linux-aarch64.tar.gz",
+      "sha256": "87809aca568009fcd90bd50e0e189444915f3a2e33e459f6c9bc46fa466fe769"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.3.2/trigger-command-0.3.2-windows-amd64.tar.gz",
+      "sha256": "2d25b50d8cab4862810b4a82b1cf1a51090cc0a1c7aed48fe454a93670c5ad4a"
+    }
+  ]
+}

--- a/manifests/trigger-mqtt/trigger-mqtt.json
+++ b/manifests/trigger-mqtt/trigger-mqtt.json
@@ -1,39 +1,39 @@
 {
   "name": "trigger-mqtt",
   "description": "A Spin trigger for MQTT events",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "spinCompatibility": ">=2.0",
   "license": "MIT",
   "packages": [
     {
       "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.5.0/trigger-mqtt-0.5.0-linux-amd64.tar.gz",
+      "sha256": "e31fb01c100f9f67f7f7b38f0ba3b73444120e049786b8c6bb47ffee33dea14d"
+    },
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.5.0/trigger-mqtt-0.5.0-macos-amd64.tar.gz",
+      "sha256": "0cc44b859d7e7eda9ba20213a6dda65f7c2df3188bacb8c28d557f73b2105a4c"
+    },
+    {
+      "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-linux-aarch64.tar.gz",
-      "sha256": "6f1b6e5df7e723682ee8a6acf29282621c889bc3ccd01d1c22194d6df236c893"
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.5.0/trigger-mqtt-0.5.0-macos-aarch64.tar.gz",
+      "sha256": "dc506dea4ce649d2f544e72490b275424a27561ef2bcdc4b16008e5ba459ce85"
+    },
+    {
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.5.0/trigger-mqtt-0.5.0-linux-aarch64.tar.gz",
+      "sha256": "6532d597b53b8e8faf093a721d24668317ecdaf80536415f49207bb250d30489"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-windows-amd64.tar.gz",
-      "sha256": "4f84a637680ab34964c78f65b1fea3110e611842570176f93739f7190812ff30"
-    },
-    {
-      "os": "macos",
-      "arch": "aarch64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-macos-aarch64.tar.gz",
-      "sha256": "db96bd9838111fdf5f9ebaca7fb4e66d73b946dd36a844fef28215c6daa3634e"
-    },
-    {
-      "os": "macos",
-      "arch": "amd64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-macos-amd64.tar.gz",
-      "sha256": "c9123dc73d0039daaa18a193c59f100f08a72b1e778e050a8674d683e622ad74"
-    },
-    {
-      "os": "linux",
-      "arch": "amd64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-linux-amd64.tar.gz",
-      "sha256": "8d8c3739a09e5495e89554fba54f7d67578caf8b318d14ce9ad1bacac386fa62"
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.5.0/trigger-mqtt-0.5.0-windows-amd64.tar.gz",
+      "sha256": "1ed646cb86da4311495bcf1e72045d5835322e1f5ba499fb45f1e92904c7306a"
     }
   ]
 }

--- a/manifests/trigger-mqtt/trigger-mqtt@0.4.1.json
+++ b/manifests/trigger-mqtt/trigger-mqtt@0.4.1.json
@@ -1,0 +1,39 @@
+{
+  "name": "trigger-mqtt",
+  "description": "A Spin trigger for MQTT events",
+  "version": "0.4.1",
+  "spinCompatibility": ">=2.0",
+  "license": "MIT",
+  "packages": [
+    {
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-linux-aarch64.tar.gz",
+      "sha256": "37609a77dbe2ad6548ad2c2c9f149771d8e695d04021051f3ca054ec17cf7e82"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-windows-amd64.tar.gz",
+      "sha256": "fc79059cfa69983a591b0559ae55891cb33c992a362f31b932e39cdb1ff8a1f7"
+    },
+    {
+      "os": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-macos-aarch64.tar.gz",
+      "sha256": "60bdc1a83b4075092469096cd08b00545e852826b45e00f34fe349ee9269da64"
+    },
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-macos-amd64.tar.gz",
+      "sha256": "0939f97258365ecfcefe24cff7232a2b77a94c575025f37b48d9ba825b7d2355"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-linux-amd64.tar.gz",
+      "sha256": "651bd5f524211632e378ccdc2507c81e40b5dfbca34b2503961f96f8a5820c3d"
+    }
+  ]
+}

--- a/manifests/trigger-mqtt/trigger-mqtt@0.4.2.json
+++ b/manifests/trigger-mqtt/trigger-mqtt@0.4.2.json
@@ -1,39 +1,39 @@
 {
   "name": "trigger-mqtt",
   "description": "A Spin trigger for MQTT events",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "spinCompatibility": ">=2.0",
   "license": "MIT",
   "packages": [
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-linux-aarch64.tar.gz",
-      "sha256": "37609a77dbe2ad6548ad2c2c9f149771d8e695d04021051f3ca054ec17cf7e82"
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-linux-aarch64.tar.gz",
+      "sha256": "6f1b6e5df7e723682ee8a6acf29282621c889bc3ccd01d1c22194d6df236c893"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-windows-amd64.tar.gz",
-      "sha256": "fc79059cfa69983a591b0559ae55891cb33c992a362f31b932e39cdb1ff8a1f7"
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-windows-amd64.tar.gz",
+      "sha256": "4f84a637680ab34964c78f65b1fea3110e611842570176f93739f7190812ff30"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-macos-aarch64.tar.gz",
-      "sha256": "60bdc1a83b4075092469096cd08b00545e852826b45e00f34fe349ee9269da64"
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-macos-aarch64.tar.gz",
+      "sha256": "db96bd9838111fdf5f9ebaca7fb4e66d73b946dd36a844fef28215c6daa3634e"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-macos-amd64.tar.gz",
-      "sha256": "0939f97258365ecfcefe24cff7232a2b77a94c575025f37b48d9ba825b7d2355"
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-macos-amd64.tar.gz",
+      "sha256": "c9123dc73d0039daaa18a193c59f100f08a72b1e778e050a8674d683e622ad74"
     },
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.1/trigger-mqtt-0.4.1-linux-amd64.tar.gz",
-      "sha256": "651bd5f524211632e378ccdc2507c81e40b5dfbca34b2503961f96f8a5820c3d"
+      "url": "https://github.com/spinframework/spin-trigger-mqtt/releases/download/v0.4.2/trigger-mqtt-0.4.2-linux-amd64.tar.gz",
+      "sha256": "8d8c3739a09e5495e89554fba54f7d67578caf8b318d14ce9ad1bacac386fa62"
     }
   ]
 }

--- a/manifests/trigger-sqs/trigger-sqs.json
+++ b/manifests/trigger-sqs/trigger-sqs.json
@@ -1,39 +1,39 @@
 {
   "name": "trigger-sqs",
   "description": "A Spin trigger for Amazon SQS events",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "spinCompatibility": ">=2.2",
   "license": "Apache-2.0",
   "packages": [
     {
-      "os": "linux",
-      "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-linux-aarch64.tar.gz",
-      "sha256": "8114e10d85cd00bca7f6797d782b80950e905489397a627aab6ffa7e06757638"
-    },
-    {
       "os": "macos",
-      "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-macos-aarch64.tar.gz",
-      "sha256": "78e7c6c86baaf15090e12c2002e14302c0a68913abfc4b7febf7f5c3ae372035"
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.10.0/trigger-sqs-0.10.0-macos-amd64.tar.gz",
+      "sha256": "4188a3fe676c759d5c9c6cdbd822017cb60e99f5c8e9c603e459f1a496e5619b"
     },
     {
       "os": "linux",
-      "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-linux-amd64.tar.gz",
-      "sha256": "f4a10198e4cdee8f55f9623b205625ffea720c847c567c3632b86a0fd30da61e"
-    },
-    {
-      "os": "macos",
-      "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-macos-amd64.tar.gz",
-      "sha256": "b882c9f116826e632909e176ee4c144013dccd8a54239f9b98ab3f6d1c490955"
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.10.0/trigger-sqs-0.10.0-linux-aarch64.tar.gz",
+      "sha256": "e7c5a959232abcb6b0e95da37c9bf687dbdc24f05060d996b5751fa72d099649"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-windows-amd64.tar.gz",
-      "sha256": "1a5fdb0a5442ea5df5658a5935e54eecc86dcb0258c51890acefc87a8b1c4d73"
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.10.0/trigger-sqs-0.10.0-windows-amd64.tar.gz",
+      "sha256": "9fcaaabf11cf559444eb4bda4f8133e1400ab893ab1f36b62f5e070d4fae29b4"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.10.0/trigger-sqs-0.10.0-linux-amd64.tar.gz",
+      "sha256": "0050215529a8b5b9d9ec00fd21e123ee8862a4201cb72ac2ea72fe810775bc0f"
+    },
+    {
+      "os": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.10.0/trigger-sqs-0.10.0-macos-aarch64.tar.gz",
+      "sha256": "5de27faeecdbf120f2f54a078b0346227569071bb2a2a8eba95e6da4ad5d83a5"
     }
   ]
 }

--- a/manifests/trigger-sqs/trigger-sqs@0.9.1.json
+++ b/manifests/trigger-sqs/trigger-sqs@0.9.1.json
@@ -1,0 +1,39 @@
+{
+  "name": "trigger-sqs",
+  "description": "A Spin trigger for Amazon SQS events",
+  "version": "0.9.1",
+  "spinCompatibility": ">=2.2",
+  "license": "Apache-2.0",
+  "packages": [
+    {
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-linux-aarch64.tar.gz",
+      "sha256": "4bdfc1136de8125a31044140ad293c2efa0d059a874d64a0c9cdb22437b7bd0e"
+    },
+    {
+      "os": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-macos-aarch64.tar.gz",
+      "sha256": "2ae692436d0f0bda9161f95c31a77e3e4e1c279f6ab0e5dc9b84e493950a5a31"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-linux-amd64.tar.gz",
+      "sha256": "503ed834ee3844b9b168079d22867f2cf0156da7e5c0382d49e208491c1bdf45"
+    },
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-macos-amd64.tar.gz",
+      "sha256": "8b1646a6c0fd103d1dd35168819b6d165573f57a92b3fc3b5d1c452c467a5707"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-windows-amd64.tar.gz",
+      "sha256": "992fee01c0964d904aca6b5ac1c8249bdf29ae85088a38b1c6ef4efb1aceb3c1"
+    }
+  ]
+}

--- a/manifests/trigger-sqs/trigger-sqs@0.9.2.json
+++ b/manifests/trigger-sqs/trigger-sqs@0.9.2.json
@@ -1,39 +1,39 @@
 {
   "name": "trigger-sqs",
   "description": "A Spin trigger for Amazon SQS events",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "spinCompatibility": ">=2.2",
   "license": "Apache-2.0",
   "packages": [
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-linux-aarch64.tar.gz",
-      "sha256": "4bdfc1136de8125a31044140ad293c2efa0d059a874d64a0c9cdb22437b7bd0e"
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-linux-aarch64.tar.gz",
+      "sha256": "8114e10d85cd00bca7f6797d782b80950e905489397a627aab6ffa7e06757638"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-macos-aarch64.tar.gz",
-      "sha256": "2ae692436d0f0bda9161f95c31a77e3e4e1c279f6ab0e5dc9b84e493950a5a31"
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-macos-aarch64.tar.gz",
+      "sha256": "78e7c6c86baaf15090e12c2002e14302c0a68913abfc4b7febf7f5c3ae372035"
     },
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-linux-amd64.tar.gz",
-      "sha256": "503ed834ee3844b9b168079d22867f2cf0156da7e5c0382d49e208491c1bdf45"
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-linux-amd64.tar.gz",
+      "sha256": "f4a10198e4cdee8f55f9623b205625ffea720c847c567c3632b86a0fd30da61e"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-macos-amd64.tar.gz",
-      "sha256": "8b1646a6c0fd103d1dd35168819b6d165573f57a92b3fc3b5d1c452c467a5707"
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-macos-amd64.tar.gz",
+      "sha256": "b882c9f116826e632909e176ee4c144013dccd8a54239f9b98ab3f6d1c490955"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.1/trigger-sqs-0.9.1-windows-amd64.tar.gz",
-      "sha256": "992fee01c0964d904aca6b5ac1c8249bdf29ae85088a38b1c6ef4efb1aceb3c1"
+      "url": "https://github.com/fermyon/spin-trigger-sqs/releases/download/v0.9.2/trigger-sqs-0.9.2-windows-amd64.tar.gz",
+      "sha256": "1a5fdb0a5442ea5df5658a5935e54eecc86dcb0258c51890acefc87a8b1c4d73"
     }
   ]
 }


### PR DESCRIPTION
Additionally fixes a few wrongly named manifests from the previous release cycle.

Draft until the manifests are actually published.