### PR TITLE
chore(manifests/aka): update all S3 urls to use https

### DIFF
--- a/manifests/aka/aka@0.3.0.json
+++ b/manifests/aka/aka@0.3.0.json
@@ -9,31 +9,31 @@
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-macos-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-macos-aarch64.tar.gz",
       "sha256": "5834092411717288ab9f216401481cc1c326184af5aaff52aa26a3680cd15af9"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-linux-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-linux-aarch64.tar.gz",
       "sha256": "694ca8b2518d34fbbf7ae48d3b9b940e7054a13d6aedbe73a36c7fc0747e2788"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-windows-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-windows-amd64.tar.gz",
       "sha256": "f61a26ac3b79b02d55d2530830ac88930483dc8b78116923411c5771bc98bb7d"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-macos-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-macos-amd64.tar.gz",
       "sha256": "d04702d12ccddfce6d22ab5f9f6d4a6ce6e150090dcede8fc09411d97a4eb04d"
     },
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-linux-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.0-linux-amd64.tar.gz",
       "sha256": "22f2a2b70f15866999693e70b5323c498a1e3b4ae2a6c1f71c84395b717cbb0b"
     }
   ]

--- a/manifests/aka/aka@0.3.1.json
+++ b/manifests/aka/aka@0.3.1.json
@@ -9,31 +9,31 @@
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-macos-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-macos-aarch64.tar.gz",
       "sha256": "6ff0dee99fb2550707ff58d4f08d555ddf58c324673bafcd9617f3b9deaeb5a1"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-linux-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-linux-aarch64.tar.gz",
       "sha256": "f58e3b92a890cf8fe30dddb6eb512920f844056d1365c421803e0b84ea461161"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-windows-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-windows-amd64.tar.gz",
       "sha256": "9e5efbcec31c420ee0fe596e44f7ca0c2e7ac34fd5a99ac2e6e97d34e42b0bd4"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-macos-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-macos-amd64.tar.gz",
       "sha256": "02d3c642a42f69cb7a204249ca83eff243708f830d409a537b6e8a1dfe5a42d3"
     },
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-linux-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.3.1-linux-amd64.tar.gz",
       "sha256": "65e0327413c8c1e7ab89b7918dcfb866850737a3e35fe270e9b574499ea3a122"
     }
   ]

--- a/manifests/aka/aka@0.4.0.json
+++ b/manifests/aka/aka@0.4.0.json
@@ -9,31 +9,31 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-linux-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-linux-amd64.tar.gz",
       "sha256": "6ce7efebf5a535b358c04f863505dd6ec2f26d18aef40b2825a1fcd05d9bd03e"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-linux-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-linux-aarch64.tar.gz",
       "sha256": "9e858e816492269ace34d382706ff347c65777f7d01d1af9027d004b6c80cebf"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-macos-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-macos-amd64.tar.gz",
       "sha256": "65cd23b72988966cc69bbe705e914892b849d4a9334daeff9707a8f676b96398"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-windows-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-windows-amd64.tar.gz",
       "sha256": "3aff40954ba381b4029d4d90c1ea3037a2b47fa3445e1805d85a6c3d248ed233"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-macos-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.0-macos-aarch64.tar.gz",
       "sha256": "7f6b1a9908130e0454b43c3800552270cff5f14d3732cb95e0803a08dbf77552"
     }
   ]

--- a/manifests/aka/aka@0.4.1.json
+++ b/manifests/aka/aka@0.4.1.json
@@ -9,31 +9,31 @@
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-macos-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-macos-aarch64.tar.gz",
       "sha256": "6ab1d3630b4b8ebe43a9d7460385eb27f4cfb0d98b12c25da810d1ab6bfdc280"
     },
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-linux-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-linux-amd64.tar.gz",
       "sha256": "985889df28f2f2873600f6554217d5d1eb03021024beec35ff0eb7b941f37799"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-windows-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-windows-amd64.tar.gz",
       "sha256": "b18b1affee740c0a5e9f253a529fb7e9e9331ae3399ba0720311c6836d3a12ed"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-macos-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-macos-amd64.tar.gz",
       "sha256": "6abc0f391be6e1fdc32408ae3babd0c2147908c0c37f3e811e0d04631bd4013b"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-linux-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.1-linux-aarch64.tar.gz",
       "sha256": "9cdf4f0a6dea6a76d342c1854c5bd58dfefe420d5cdfb0e24e52c924907febd8"
     }
   ]

--- a/manifests/aka/aka@0.4.2.json
+++ b/manifests/aka/aka@0.4.2.json
@@ -9,31 +9,31 @@
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-macos-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-macos-aarch64.tar.gz",
       "sha256": "b9f8678613bbee9ab79cd037eb19f674da0f57f3363b11c4c344d5109df7d8fd"
     },
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-linux-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-linux-amd64.tar.gz",
       "sha256": "4b8cab21b509733bbc6a88c2725fe66aa0128244e2ec5f797d5ef5f47618d574"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-windows-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-windows-amd64.tar.gz",
       "sha256": "2d9b1c489d0e15074d1552e64f4250dcfa000a72baed12d5004688c9ff4aad71"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-macos-amd64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-macos-amd64.tar.gz",
       "sha256": "491e27a962702eb3dd935bcecc4c004ee3e215b3655e8108f99e1d5fb30b0f75"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "http://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-linux-aarch64.tar.gz",
+      "url": "https://s3.amazonaws.com/fermyon-neutrino-artifacts-public/plugin/aka-0.4.2-linux-aarch64.tar.gz",
       "sha256": "88f799e05efc943948ea9d07f8d1bf022098ab87f06a2ba0f7c1ae02a85425dc"
     }
   ]


### PR DESCRIPTION
Not sure the genesis of using `http` as the scheme, but `https` is preferred, even though today one can download without.